### PR TITLE
fix(editor): Ensure JetBrains Mono font is loaded and applied

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,9 @@
     <title>Razen Studio</title>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-okaidia.min.css">
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Work+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&family=Work+Sans:wght@400;500;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>

--- a/style.css
+++ b/style.css
@@ -121,7 +121,7 @@ main {
     border: none;
     resize: none;
     padding: 1rem;
-    font-family: 'JetBrains Mono', monospace;
+    font-family: 'JetBrains Mono', monospace !important;
     font-size: 14px;
     line-height: 1.5;
     outline: none;
@@ -142,7 +142,7 @@ main {
     height: 100%;
     margin: 0;
     padding: 1rem;
-    font-family: 'JetBrains Mono', monospace;
+    font-family: 'JetBrains Mono', monospace !important;
     font-size: 14px;
     line-height: 1.5;
     overflow: auto;


### PR DESCRIPTION
This commit fixes an issue where the JetBrains Mono font was not being correctly applied to the code editor.

The following changes are included:

- **Specific Font Import:** The Google Fonts import in `index.html` has been updated to be more specific and include a wider range of weights for JetBrains Mono.
- **Force Font Application:** The `!important` rule has been added to the `font-family` property for the editor and highlighting elements in `style.css`. This ensures that the JetBrains Mono font is applied, overriding any conflicting styles.