### PR TITLE
Fix: Settings menu not functional after nav toggle implementation

### DIFF
--- a/script.js
+++ b/script.js
@@ -750,6 +750,12 @@ fn main() {
     window.addEventListener('click', (e) => {
         const navMenu = document.getElementById('nav-menu');
         const navToggleBtn = document.getElementById('nav-toggle-btn');
+
+        // If the click is on a settings button, do nothing.
+        if (e.target.closest('.settings-nav-btn')) {
+            return;
+        }
+
         if (navMenu && navMenu.classList.contains('show')) {
             // Check if the click was outside the menu and its toggle button
             if (!navMenu.contains(e.target) && !navToggleBtn.contains(e.target)) {


### PR DESCRIPTION
The settings menu was not working because the global click listener, added for the new navigation toggle, was interfering with the settings menu's click events.

This fix modifies the global click listener in `script.js` to ignore clicks on the settings menu buttons, allowing them to function as expected.