### PR TITLE
Fix(android): Use app-specific storage for projects

### DIFF
--- a/Android/app/src/main/java/com/basaicorp/razenstudio/WebAppInterface.java
+++ b/Android/app/src/main/java/com/basaicorp/razenstudio/WebAppInterface.java
@@ -27,7 +27,10 @@ public class WebAppInterface {
     }
 
     private File getProjectsRoot() {
-        File root = new File(Environment.getExternalStorageDirectory(), PROJECTS_DIR);
+        // Use the app-specific directory to comply with Scoped Storage.
+        // This does not require special permissions.
+        File appSpecificDir = context.getExternalFilesDir(null);
+        File root = new File(appSpecificDir, PROJECTS_DIR);
         if (!root.exists()) {
             root.mkdirs();
         }


### PR DESCRIPTION
The application was failing to create new project directories on modern versions of Android, resulting in a 'Could not create project directory' error.

This was caused by the use of the deprecated `Environment.getExternalStorageDirectory()` API, which is restricted on apps targeting SDK 30+ due to Scoped Storage policies.

The code has been updated in `WebAppInterface.java` to use `context.getExternalFilesDir(null)`, which saves project files to the app's private, sandboxed external storage directory. This is the correct approach for modern Android development and resolves the file creation error without requiring legacy storage permissions.