### PR TITLE
feat: Implemented file context menu with more options

### DIFF
--- a/filesystem.js
+++ b/filesystem.js
@@ -175,6 +175,46 @@ const FileSystem = {
             console.warn(`FS Fallback: Importing files to ${relativePath}`);
             return Promise.resolve({ success: false, message: "Not implemented in browser." });
         }
+    },
+
+    async rename(projectName, relativePath, newName) {
+        if (this.isAndroid()) {
+            const result = await window.Android.rename(projectName, relativePath, newName);
+            return { success: result === "Success", message: result };
+        } else {
+            // Fallback implementation
+            return { success: false, message: "Not implemented in browser." };
+        }
+    },
+
+    async copy(projectName, relativePath, destinationRelativePath) {
+        if (this.isAndroid()) {
+            const result = await window.Android.copy(projectName, relativePath, destinationRelativePath);
+            return { success: result === "Success", message: result };
+        } else {
+            // Fallback implementation
+            return { success: false, message: "Not implemented in browser." };
+        }
+    },
+
+    async cut(projectName, relativePath) {
+        if (this.isAndroid()) {
+            const result = await window.Android.cut(projectName, relativePath);
+            return { success: result === "Success", message: result };
+        } else {
+            // Fallback implementation
+            return { success: false, message: "Not implemented in browser." };
+        }
+    },
+
+    async paste(projectName, destinationRelativePath) {
+        if (this.isAndroid()) {
+            const result = await window.Android.paste(projectName, destinationRelativePath);
+            return { success: result === "Success", message: result };
+        } else {
+            // Fallback implementation
+            return { success: false, message: "Not implemented in browser." };
+        }
     }
 };
 

--- a/index.html
+++ b/index.html
@@ -27,6 +27,15 @@
             <div id="file-list" class="file-list"></div>
             <div id="file-context-menu" class="context-menu" style="display: none;">
                 <ul>
+                    <li id="context-menu-copy"><i class="fas fa-copy"></i> Copy</li>
+                    <li id="context-menu-cut"><i class="fas fa-cut"></i> Cut</li>
+                    <li id="context-menu-paste"><i class="fas fa-paste"></i> Paste</li>
+                    <li id="context-menu-rename"><i class="fas fa-i-cursor"></i> Rename</li>
+                    <li id="context-menu-copy-path"><i class="fas fa-link"></i> Copy Path</li>
+                    <li id="context-menu-preview"><i class="fas fa-eye"></i> Show Preview</li>
+                    <li class="context-menu-divider"></li>
+                    <li id="context-menu-download"><i class="fas fa-download"></i> Download</li>
+                    <li class="context-menu-divider"></li>
                     <li id="context-menu-delete"><i class="fas fa-trash-alt"></i> Delete</li>
                 </ul>
             </div>

--- a/style.css
+++ b/style.css
@@ -121,6 +121,18 @@ body {
     text-align: center;
 }
 
+.context-menu-divider {
+    height: 1px;
+    background-color: var(--border-color);
+    margin: 4px 0;
+}
+
+.context-menu li.disabled {
+    color: var(--text-secondary);
+    cursor: not-allowed;
+    background-color: transparent;
+}
+
 .main-content {
     flex: 1;
     display: flex;


### PR DESCRIPTION
This commit implements a file context menu with the following options:
- Copy
- Cut
- Paste
- Rename
- Copy Path
- Show Preview (for HTML files)
- Download
- Delete

The implementation includes the following changes:
- `WebAppInterface.java`: Added new methods for file operations (copy, cut, paste, rename).
- `index.html`: Added the new options to the context menu.
- `style.css`: Added styles for the new context menu items.
- `script.js`: Added event listeners and logic for the new context menu items.
- `filesystem.js`: Updated the FileSystem object to include the new file operation methods.