### PR TITLE
style: Adjust syntax highlighting colors to a lighter tone

### DIFF
--- a/languages/razen.js
+++ b/languages/razen.js
@@ -290,8 +290,8 @@ function registerRazenLanguage() {
         rules: [
             { token: 'comment', foreground: '608b4e' },
             { token: 'entity.name.library', foreground: '98C379' },
-            { token: 'variable.name', foreground: '82AAFF' },
-            { token: 'entity.name.function', foreground: 'FFCB6B' }
+            { token: 'variable.name', foreground: 'A6C1FF' },
+            { token: 'entity.name.function', foreground: 'FFF59D' }
         ],
         colors: { 'editor.background': '#1e1e2e' }
     });
@@ -299,8 +299,8 @@ function registerRazenLanguage() {
         base: 'vs', inherit: true,
         rules: [
             { token: 'comment', foreground: '6a737d' },
-            { token: 'variable.name', foreground: '0000FF' },
-            { token: 'entity.name.function', foreground: 'B8860B' }
+            { token: 'variable.name', foreground: '42A5F5' },
+            { token: 'entity.name.function', foreground: 'FFD54F' }
         ],
         colors: { 'editor.background': '#ffffff' }
     });


### PR DESCRIPTION
This commit adjusts the syntax highlighting colors for variables and functions to use a lighter, more subtle tone as requested.

- The blue for variable names is now lighter.
- The yellow for function names is now lighter and less saturated.