### PR TITLE
feat: Add syntax highlighting for variable usage

### DIFF
--- a/languages/razen.js
+++ b/languages/razen.js
@@ -164,7 +164,7 @@ function registerRazenLanguage() {
                         'fun': { token: 'keyword', next: '@function_declaration' },
                         'read': { token: 'keyword', next: '@read_statement' },
                         '@keywords': 'keyword',
-                        '@default': 'identifier'
+                        '@default': 'variable.name'
                     }
                 }],
 


### PR DESCRIPTION
This commit updates the tokenizer rules to highlight variable usage, in addition to variable declarations.

Any identifier that is not a keyword or a function call will now be highlighted with the variable color. This provides a more comprehensive highlighting of variables throughout the code.