### PR TITLE
fix: Correct language client initialization to fix editor loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/marked/lib/marked.umd.js"></script>
     <script src="monaco/package/min/vs/loader.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/vscode-ws-jsonrpc@2.0.0/dist/index.umd.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vscode-jsonrpc@8.1.0/lib/browser/main.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/monaco-languageclient@7.0.0/dist/index.umd.js"></script>
     <script>
         // Improved theme detection script

--- a/script.js
+++ b/script.js
@@ -661,7 +661,8 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Monaco Editor Initialization ---
     require.config({ paths: { vs: 'monaco/package/min/vs' } });
     require(['vs/editor/editor.main'], function () {
-        const { MonacoLanguageClient, CloseAction, ErrorAction, MonacoServices } = monaco_languageclient;
+        const { MonacoLanguageClient, CloseAction, ErrorAction, MonacoServices } = monacoLanguageclient;
+        const { BrowserMessageReader, BrowserMessageWriter } = vscodeJsonrpc;
 
         const languageId = 'razen';
         registerRazenLanguage();
@@ -673,8 +674,8 @@ document.addEventListener('DOMContentLoaded', () => {
         const worker = new Worker('languages/razen/razen-worker.js', { type: 'module' });
 
         const channel = new MessageChannel();
-        const reader = new monaco_languageclient.BrowserMessageReader(channel.port1);
-        const writer = new monaco_languageclient.BrowserMessageWriter(channel.port1);
+        const reader = new BrowserMessageReader(channel.port1);
+        const writer = new BrowserMessageWriter(channel.port1);
         worker.postMessage({ port: channel.port2 }, [channel.port2]);
 
         const languageClient = createLanguageClient({ reader, writer });


### PR DESCRIPTION
This commit fixes a critical bug that prevented the Monaco editor from loading. The issue was caused by incorrect library references and initialization logic for the language client.

- Replaced the `vscode-ws-jsonrpc` CDN script with `vscode-jsonrpc`, which is the correct library for web worker communication without WebSockets.
- Updated `script.js` to use the correct global variables (`monacoLanguageclient`, `vscodeJsonrpc`) exposed by the UMD bundles.
- Correctly instantiated `BrowserMessageReader` and `BrowserMessageWriter` from the `vscodeJsonrpc` library.

These changes resolve the JavaScript errors that were blocking the editor's initialization, allowing the application to load correctly while maintaining the language server integration.